### PR TITLE
Add ravel-logd agent for log managment

### DIFF
--- a/cmd/ravel-logd/ravel-logd.go
+++ b/cmd/ravel-logd/ravel-logd.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"github.com/valyentdev/ravel/internal/logd"
+)
+
+var (
+	configPath = flag.String("config", "/etc/ravel/logd.yaml", "Path to the config file")
+)
+
+func init() {
+	flag.Parse()
+
+}
+
+func main() {
+
+	// Load the config
+	config, err := logd.LoadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Get logs file from config
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	_, ctx, err = logd.NewLogger(ctx)
+	if err != nil {
+		log.Fatalf("Failed to create logger: %v", err)
+	}
+
+	// Create a new LogManager
+	logWatcherSvc, err := logd.NewLogWatcherService(config)
+	if err != nil {
+		log.Fatalf("Failed to create LogManager: %v", err)
+	}
+
+	// Start the LogManager
+	go logWatcherSvc.Start(ctx)
+
+	// Wait for a signal to stop
+	<-ctx.Done()
+
+	// TODO:jnfrati - Add a graceful shutdown
+	// Do we want to wait for all loggers to reach EOF?
+	// Or do we want to stop all loggers immediately?
+}

--- a/internal/logd/config.go
+++ b/internal/logd/config.go
@@ -1,0 +1,57 @@
+package logd
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+)
+
+const LOGS_DIRECTORY = "/var/log/ravel"
+
+type LogdConfig struct {
+	Exporter       string                 `json:"exporter" default:"stdout"`
+	ExporterConfig map[string]interface{} `json:"exporter_config"`
+}
+
+func LoadConfig(filePath string) (*LogdConfig, error) {
+
+	// Load the config
+	var config LogdConfig
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(bytes, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func NewLogger(ctx context.Context) (*log.Logger, context.Context, error) {
+	logFile := LOGS_DIRECTORY
+	writer, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, ctx, err
+	}
+
+	defer writer.Close()
+
+	l := log.New(writer, "", log.LstdFlags)
+
+	ctx = context.WithValue(ctx, LoggerKey, l)
+
+	return l, ctx, nil
+}
+
+func GetLogger(ctx context.Context) (*log.Logger, error) {
+	l := ctx.Value(LoggerKey)
+	if l == nil {
+		return nil, nil
+	}
+
+	return l.(*log.Logger), nil
+}

--- a/internal/logd/context.go
+++ b/internal/logd/context.go
@@ -1,0 +1,7 @@
+package logd
+
+type LogdContextKey string
+
+const (
+	LoggerKey LogdContextKey = "logger"
+)

--- a/internal/logd/exporter.go
+++ b/internal/logd/exporter.go
@@ -1,0 +1,28 @@
+package logd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/valyentdev/ravel/pkg/core"
+)
+
+type Exporter interface {
+	Send(*core.LogEntry) error
+}
+
+type StdoutExporter struct{}
+
+func (s *StdoutExporter) Send(log *core.LogEntry) error {
+	_, err := fmt.Printf("%s %s %s %s %s\n", time.Unix(log.Timestamp, 0).Format(time.RFC3339), log.InstanceId, log.Source, log.Level, log.Message)
+	return err
+}
+
+func NewExporter(config *LogdConfig) (Exporter, error) {
+	switch config.Exporter {
+	case "stdout":
+		return &StdoutExporter{}, nil
+	default:
+		return nil, fmt.Errorf("unknown exporter: %s", config.Exporter)
+	}
+}

--- a/internal/logd/logd.go
+++ b/internal/logd/logd.go
@@ -1,0 +1,58 @@
+package logd
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+type LogManager struct {
+	Loggers map[string]*Logger
+
+	Queue chan *Logger
+
+	Exporter Exporter
+}
+
+func NewLogWatcherService(config *LogdConfig) (*LogManager, error) {
+	exporter, err := NewExporter(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create exporter")
+	}
+
+	return &LogManager{
+		Loggers:  make(map[string]*Logger),
+		Queue:    make(chan *Logger),
+		Exporter: exporter,
+	}, nil
+}
+
+// Start service will create a goroutine that's going to listen for a new logger on the loggers channel
+// When a new logger is received, it will:
+// - Check if the logger is already running
+// - If the max number of loggers is reached, it will wait till a logger is removed from the loggers map
+// - If not, it will wait till it can add a new goroutine to the loggers map
+// - Start the logger
+// - Add the logger to the loggers map
+func (m *LogManager) Start(ctx context.Context) {
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case logger := <-m.Queue:
+			if _, ok := m.Loggers[logger.InstanceID]; ok {
+				continue
+			}
+
+			m.Loggers[logger.InstanceID] = logger
+
+			go logger.Start(ctx, m.Exporter)
+		}
+
+	}
+}
+
+func (m *LogManager) RegisterLogger(logger *Logger) {
+	m.Queue <- logger
+}

--- a/internal/logd/logd_test.go
+++ b/internal/logd/logd_test.go
@@ -1,0 +1,134 @@
+package logd_test
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/containerd/console"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyentdev/ravel/internal/logd"
+	"github.com/valyentdev/ravel/pkg/core"
+)
+
+// Channel exporter will send logs to a channel, this is with only testing purposes and should not be used in production
+type ChannelExporter struct {
+	Channel chan *core.LogEntry
+}
+
+func NewChannelExporter() *ChannelExporter {
+	return &ChannelExporter{
+		Channel: make(chan *core.LogEntry),
+	}
+}
+
+func (c *ChannelExporter) Send(log *core.LogEntry) error {
+	c.Channel <- log
+	return nil
+}
+
+type FakeMachine struct {
+	instanceId string
+	namespace  string
+	machineId  string
+	ptyPath    string
+	console    console.Console
+}
+
+func NewFakeMachine(instanceId, namespace, machineId string) (*FakeMachine, error) {
+	c, path, err := console.NewPty()
+	if err != nil {
+		return nil, err
+	}
+
+	return &FakeMachine{
+		instanceId: instanceId,
+		namespace:  namespace,
+		machineId:  machineId,
+		ptyPath:    path,
+		console:    c,
+	}, nil
+}
+
+func (f *FakeMachine) GetLogger() *logd.Logger {
+	return &logd.Logger{
+		InstanceID: f.instanceId,
+		Namespace:  f.namespace,
+		MachineID:  f.machineId,
+		PtyPath:    f.ptyPath,
+	}
+}
+
+func (f *FakeMachine) Close() {
+	f.console.Close()
+}
+
+func (f *FakeMachine) Write(data []byte) {
+	f.console.Write(data)
+}
+
+func TestWatcher(t *testing.T) {
+	l := log.New(log.Writer(), "", log.LstdFlags)
+
+	l.Println("Start test")
+	// Create a new channel exporter
+	exporter := NewChannelExporter()
+
+	l.Println("Exporter created")
+
+	// Create a new LogWatcherService with the exporter
+	logWatcherService := logd.LogManager{
+		Loggers:  make(map[string]*logd.Logger),
+		Queue:    make(chan *logd.Logger),
+		Exporter: exporter,
+	}
+	l.Println("LogWatcherService created")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the log watcher service
+	go logWatcherService.Start(ctx)
+
+	l.Println("LogWatcherService started")
+	// Create a new pty and register it with the log watcher service
+
+	machine1, err := NewFakeMachine("instance_id_1", "default", "machine_id_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer machine1.Close()
+	l.Println("Machine 1 created")
+
+	machine2, err := NewFakeMachine("instance_id_2", "default", "machine_id_2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer machine2.Close()
+	l.Println("Machine 2 created")
+
+	logWatcherService.RegisterLogger(machine1.GetLogger())
+	logWatcherService.RegisterLogger(machine2.GetLogger())
+
+	l.Println("Loggers registered")
+
+	// Write to the first machine and check if the log is received by the exporter
+	logText := "Test number 1!"
+
+	machine1.Write([]byte(logText + "\n"))
+
+	logEntry := <-exporter.Channel
+
+	assert.Equal(t, logText, logEntry.Message)
+	assert.Equal(t, "instance_id_1", logEntry.InstanceId)
+
+	// Write to the second machine and check if the log is received by the exporter
+	logText = "Test number 2!"
+
+	machine2.Write([]byte(logText + ".\n"))
+
+	logEntry = <-exporter.Channel
+
+	assert.Equal(t, logText, logEntry.Message)
+	assert.Equal(t, "instance_id_2", logEntry.InstanceId)
+}

--- a/internal/logd/logger.go
+++ b/internal/logd/logger.go
@@ -1,0 +1,76 @@
+package logd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/containerd/console"
+	"github.com/valyentdev/ravel/pkg/core"
+)
+
+type Logger struct {
+	// Info to identify the machine and instance where the logger is running
+	InstanceID string
+	Namespace  string
+	MachineID  string
+	// Path to listen for logs
+	PtyPath string
+}
+
+// Start will create a new goroutine that will listen for logs on the ptyPath
+// When a new log is received, it will send it to the exporter
+func (l *Logger) Start(ctx context.Context, exporter Exporter) error {
+	// Open the ptyPath
+	pty, err := os.Open(l.PtyPath)
+	if err != nil {
+		return err
+	}
+
+	defer pty.Close()
+
+	// Get a console from the pty
+	ptyConsole, err := console.ConsoleFromFile(pty)
+	if err != nil {
+		return err
+	}
+
+	defer ptyConsole.Close()
+
+	// Create a reader to read from the console
+	reader := bufio.NewReaderSize(ptyConsole, 4096)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+
+			line, _, err := reader.ReadLine()
+
+			if err != nil {
+				if err.Error() == "EOF" {
+					fmt.Println("EOF reached")
+					break
+				}
+			}
+
+			log := &core.LogEntry{
+				Timestamp:  time.Now().Unix(),
+				InstanceId: l.InstanceID,
+				Source:     "instance",
+				Level:      "info",
+				Message:    string(line),
+			}
+
+			// Send the log to the exporter
+			err = exporter.Send(log)
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hello here! This is the PR I promised around the `ravel-logd` as you can see, this is still a work in progress and I think it will take a bit to take it into the main branch. 

Right now it's lacking:
- A connection to the main raveld to retrieve current logs
- Exporter to vector / nats

